### PR TITLE
fix: indentation

### DIFF
--- a/ansible-deploy-k8s/master.yml
+++ b/ansible-deploy-k8s/master.yml
@@ -36,7 +36,7 @@
       register: kubernetes_join_command
 
     - debug:
-      msg: "{{ kubernetes_join_command.stdout }}"
+        msg: "{{ kubernetes_join_command.stdout }}"
 
     - name: Copy join command to local file.
       become: yes


### PR DESCRIPTION
```
ansible-playbook -i hosts master.yml

ERROR! conflicting action statements: debug, msg

The error appears to be in '~/tmp/kubernetes/ansible-deploy-k8s/master.yml': line 38, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


    - debug:
      ^ here
```